### PR TITLE
Add dst slice destructurer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ let b = User::build_from_slice(33, &[0, 1, 2, 3, 4]);
 // allocate another user, this time using an iterator
 let v = vec![0, 1, 2, 3, 4];
 let c = User::build(33, v);
+
+// destructure this user and compare its key to the vector
+// this has the advantage of iterating over u8, not &u8 or &mut u8.
+let (_age, signing_key) = User::destroy(c);
+assert!(signing_key.eq(v.into_iter()));
 ```
 Here's another example, this time using a string as the last field of a struct:
 
@@ -130,7 +135,7 @@ always return boxed instances of the structs.
 
 The common use case for the [`#[make_dst_factory]`](https://docs.rs/dst-factory/latest/dst_factory/attr.make_dst_factory.html) attribute is to not pass any arguments.
 This results in factory functions called `build` when using a string or dynamic trait as the
-last field of the struct, and `build` and `build_from_slice` when using an array as the last
+last field of the struct, and `build`, `build_from_slice`, and `destroy` when using an array as the last
 field of the struct.
 
 The generated functions are private by default and have the following signatures:
@@ -146,6 +151,8 @@ fn build_from_slice(field1, field2, ..., last_field: &[last_field_type]) -> Box<
 where
     last_field_type: Copy + Sized;
 
+fn destroy(this: Box<Self>) -> (Type1, Type2, ..., SelfIter);
+
 // for strings
 fn build(field1, field2, ..., last_field: impl AsRef<str>) -> Box<Self>;
 
@@ -160,22 +167,28 @@ visibility, and whether to generate code for the `no_std` environment. The gener
 grammar is:
 
 ```
-#[make_dst_factory(<base_factory_name>[, <visibility>] [, no_std] [, generic=<generic_name>])]
+#[make_dst_factory(<base_factory_name> [, destructor=<destructor_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, generic=<generic_name>])]
 ```
 
 Some examples:
 
 ```rust
-// The factory functions will be private and called `create` and `create_from_slice`
+// The factory functions will be public and called `build`, `build_from_slice`, and `destroy`.
+#[make_dst_factory(pub)]
+
+// The factory functions will be private and called `create`, `create_from_slice`, and `destroy`.
 #[make_dst_factory(create)]
 
-// The factory functions will be public and called `create` and `create_from_slice`
+// The factory functions will be private and called `create`, `create_from_slice`, and `destructure`.
+#[make_dst_factory(create, destructor = destructure)]
+
+// The factory functions will be public and called `create`, `create_from_slice`, and `destroy`
 #[make_dst_factory(create, pub)]
 
-// The factory functions will be private, called `create` and `create_from_slice`, and support the `no_std` environment
+// The factory functions will be private, called `create`, `create_from_slice`, and `destroy`, and support the `no_std` environment
 #[make_dst_factory(create, no_std)]
 
-// The factory functions will be private, called `create` and `create_from_slice`,
+// The factory functions will be private, called `create`, `create_from_slice`, and `destroy`,
 // support the `no_std` environment, and will have generic types called `X`.
 #[make_dst_factory(create, no_std, generic=X)]
 ```

--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ let b = User::build_from_slice(33, &[0, 1, 2, 3, 4]);
 // allocate another user, this time using an iterator
 let v = vec![0, 1, 2, 3, 4];
 let c = User::build(33, v);
-
-// destructure this user and compare its key to the vector
-// this has the advantage of iterating over u8, not &u8 or &mut u8.
-let (_age, signing_key) = User::destroy(c);
-assert!(signing_key.eq(v.into_iter()));
 ```
 Here's another example, this time using a string as the last field of a struct:
 
@@ -135,7 +130,7 @@ always return boxed instances of the structs.
 
 The common use case for the [`#[make_dst_factory]`](https://docs.rs/dst-factory/latest/dst_factory/attr.make_dst_factory.html) attribute is to not pass any arguments.
 This results in factory functions called `build` when using a string or dynamic trait as the
-last field of the struct, and `build`, `build_from_slice`, and `destroy` when using an array as the last
+last field of the struct, and `build` and `build_from_slice` when using an array as the last
 field of the struct.
 
 The generated functions are private by default and have the following signatures:
@@ -151,8 +146,6 @@ fn build_from_slice(field1, field2, ..., last_field: &[last_field_type]) -> Box<
 where
     last_field_type: Copy + Sized;
 
-fn destroy(this: Box<Self>) -> (Type1, Type2, ..., SelfIter);
-
 // for strings
 fn build(field1, field2, ..., last_field: impl AsRef<str>) -> Box<Self>;
 
@@ -167,28 +160,22 @@ visibility, and whether to generate code for the `no_std` environment. The gener
 grammar is:
 
 ```
-#[make_dst_factory(<base_factory_name> [, destructor=<destructor_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, generic=<generic_name>])]
+#[make_dst_factory(<base_factory_name>[, <visibility>] [, no_std] [, generic=<generic_name>])]
 ```
 
 Some examples:
 
 ```rust
-// The factory functions will be public and called `build`, `build_from_slice`, and `destroy`.
-#[make_dst_factory(pub)]
-
-// The factory functions will be private and called `create`, `create_from_slice`, and `destroy`.
+// The factory functions will be private and called `create` and `create_from_slice`
 #[make_dst_factory(create)]
 
-// The factory functions will be private and called `create`, `create_from_slice`, and `destructure`.
-#[make_dst_factory(create, destructor = destructure)]
-
-// The factory functions will be public and called `create`, `create_from_slice`, and `destroy`
+// The factory functions will be public and called `create` and `create_from_slice`
 #[make_dst_factory(create, pub)]
 
-// The factory functions will be private, called `create`, `create_from_slice`, and `destroy`, and support the `no_std` environment
+// The factory functions will be private, called `create` and `create_from_slice`, and support the `no_std` environment
 #[make_dst_factory(create, no_std)]
 
-// The factory functions will be private, called `create`, `create_from_slice`, and `destroy`,
+// The factory functions will be private, called `create` and `create_from_slice`,
 // support the `no_std` environment, and will have generic types called `X`.
 #[make_dst_factory(create, no_std, generic=X)]
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@ struct StructInfo<'a> {
     header_fields: Box<[&'a Field]>,
     header_field_idents: Box<[FieldIdent]>,
     header_param_idents: Box<[Ident]>,
+    header_types: Vec<Type>,
     tail_field: &'a Field,
     tail_field_ident: FieldIdent,
     tail_param_ident: Ident,
@@ -303,6 +304,8 @@ impl<'a> StructInfo<'a> {
             })
             .collect();
 
+        let header_types: Vec<_> = header_fields.iter().map(|field| field.ty.clone()).collect();
+
         let tail_param_ident = tail_field
             .ident
             .as_ref()
@@ -319,6 +322,7 @@ impl<'a> StructInfo<'a> {
             header_fields: header_fields.into_boxed_slice(),
             header_field_idents: header_field_idents.into_boxed_slice(),
             header_param_idents: header_param_idents.into_boxed_slice(),
+            header_types,
             tail_field,
             tail_field_ident,
             tail_param_ident,
@@ -372,12 +376,24 @@ fn tail_layout<T: quote::ToTokens>(tail_type: &T, span: Span) -> TokenStream {
     quote_spanned! { span => ::core::alloc::Layout::array::<#tail_type>(len).expect("Array exceeds maximum size allowed of isize::MAX") }
 }
 
-fn guard_type(macro_args: &MacroArgs) -> TokenStream {
-    let dealloc_path = if macro_args.no_std {
+fn dealloc_path(no_std: bool) -> TokenStream {
+    if no_std {
         quote! { ::alloc::alloc::dealloc }
     } else {
         quote! { ::std::alloc::dealloc }
-    };
+    }
+}
+
+fn box_path(no_std: bool) -> TokenStream {
+    if no_std {
+        quote! { ::alloc::boxed::Box }
+    } else {
+        quote! { ::std::boxed::Box }
+    }
+}
+
+fn guard_type(macro_args: &MacroArgs) -> TokenStream {
+    let dealloc_path = dealloc_path(macro_args.no_std);
 
     quote! {
         struct Guard<T> {
@@ -433,29 +449,19 @@ fn args_tuple_assignment(struct_info: &StructInfo) -> TokenStream {
     }
 }
 
-fn alloc_funcs(no_std: bool) -> (TokenStream, TokenStream) {
-    let (box_path, alloc_path, handle_alloc_error) = if no_std {
-        (
-            quote! { ::alloc::boxed::Box },
-            quote! { ::alloc::alloc::alloc },
-            quote! { panic!("out of memory") },
-        )
+fn alloc(no_std: bool) -> TokenStream {
+    let (alloc_path, handle_alloc_error) = if no_std {
+        (quote! { ::alloc::alloc::alloc }, quote! { panic!("out of memory") })
     } else {
-        (
-            quote! { ::std::boxed::Box },
-            quote! { ::std::alloc::alloc },
-            quote! { ::std::alloc::handle_alloc_error(layout) },
-        )
+        (quote! { ::std::alloc::alloc }, quote! { ::std::alloc::handle_alloc_error(layout) })
     };
 
-    let alloc = quote! {
+    quote! {
         let mem_ptr = #alloc_path(layout);
         if mem_ptr.is_null() {
             #handle_alloc_error
         }
-    };
-
-    (alloc, box_path)
+    }
 }
 
 fn alloc_zst(box_path: &TokenStream, for_trait: bool) -> TokenStream {
@@ -491,7 +497,8 @@ fn factory_for_slice_arg(macro_args: &MacroArgs, struct_info: &StructInfo, tail_
 
     factory_where_clause.predicates.push(copy_bound_tokens);
 
-    let (alloc, box_path) = alloc_funcs(macro_args.no_std);
+    let alloc = alloc(macro_args.no_std);
+    let box_path = box_path(macro_args.no_std);
     let make_zst = alloc_zst(&box_path, false);
 
     let tail_layout = tail_layout(tail_elem_type, struct_info.tail_field.ty.span());
@@ -552,7 +559,8 @@ fn factory_for_slice_arg(macro_args: &MacroArgs, struct_info: &StructInfo, tail_
 
 fn factory_for_iter_arg(macro_args: &MacroArgs, struct_info: &StructInfo, tail_type: &Type) -> TokenStream {
     let guard_type_tokens = guard_type(macro_args);
-    let (alloc, box_path) = alloc_funcs(macro_args.no_std);
+    let alloc = alloc(macro_args.no_std);
+    let box_path = box_path(macro_args.no_std);
     let make_zst = alloc_zst(&box_path, false);
 
     let tail_layout = tail_layout(tail_type, struct_info.tail_field.ty.span());
@@ -631,8 +639,102 @@ fn factory_for_iter_arg(macro_args: &MacroArgs, struct_info: &StructInfo, tail_t
     }
 }
 
+fn destructor_iterator_type(macro_args: &MacroArgs, struct_info: &StructInfo, tail_type: &Type) -> TokenStream {
+    let dealloc_path = dealloc_path(macro_args.no_std);
+
+    let visibility = &macro_args.visibility;
+    let iterator_name = macro_args
+        .iterator_name
+        .clone()
+        .unwrap_or_else(|| Ident::new(&format!("{}Iter", struct_info.struct_name), proc_macro2::Span::call_site()));
+
+    let struct_name = &struct_info.struct_name;
+    let struct_generics = &struct_info.struct_generics;
+    let (impl_generics, ty_generics, where_clause) = struct_info.struct_generics.split_for_impl();
+
+    let factory_doc = format!("Iterator type for a destructured `Box<{struct_name}>`");
+
+    quote! {
+        #[doc = #factory_doc]
+        #visibility struct #iterator_name #struct_generics #where_clause {
+            ptr: *mut #tail_type,
+            index: usize,
+            len: usize,
+
+            free_ptr: *mut u8,
+            layout: ::core::alloc::Layout,
+        }
+
+        impl #impl_generics ::core::iter::Iterator for #iterator_name #ty_generics #where_clause {
+            type Item = #tail_type;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if self.index >= self.len {
+                    return None;
+                }
+                #[allow(clippy::zst_offset)]
+                let value = unsafe { self.ptr.add(self.index).read() };
+                self.index += 1;
+                Some(value)
+            }
+        }
+
+        impl #impl_generics ::core::ops::Drop for #iterator_name #ty_generics #where_clause {
+            fn drop(&mut self) {
+                unsafe { #dealloc_path(self.free_ptr, self.layout) }
+            }
+        }
+    }
+}
+
+fn destructor_with_iter(macro_args: &MacroArgs, struct_info: &StructInfo) -> TokenStream {
+    let box_path = box_path(macro_args.no_std);
+
+    let header_fields = &struct_info.header_field_idents;
+    let header_types = &struct_info.header_types;
+
+    let visibility = &macro_args.visibility;
+    let destructor_name = &macro_args.base_destructor_name;
+
+    let tail_field = &struct_info.tail_field_ident;
+    let struct_name = &struct_info.struct_name;
+    let iterator_name = macro_args
+        .iterator_name
+        .clone()
+        .unwrap_or_else(|| Ident::new(&format!("{}Iter", struct_info.struct_name), proc_macro2::Span::call_site()));
+    let (_impl_generics, ty_generics, _where_clause) = struct_info.struct_generics.split_for_impl();
+
+    let factory_doc = format!("Destructures an instance of `Box<{struct_name}>`, returning the tail slice as an iterator.");
+
+    quote! {
+        #[doc = #factory_doc]
+        #visibility fn #destructor_name(
+            this: #box_path<Self>,
+        ) -> ( #( #header_types, )* #iterator_name #ty_generics)
+        {
+            let layout = ::core::alloc::Layout::for_value(&*this);
+            let len = this.#tail_field.len();
+            let this = #box_path::into_raw(this);
+            unsafe {
+                (
+                    #( (&raw mut (*this).#header_fields).read(), )*
+                    #iterator_name {
+                        ptr: (*this).#tail_field.as_mut_ptr(),
+                        index: 0,
+                        len,
+
+                        free_ptr: this.cast(),
+                        layout,
+                    }
+                )
+            }
+        }
+    }
+}
+
 fn factory_for_str_arg(macro_args: &MacroArgs, struct_info: &StructInfo) -> TokenStream {
-    let (alloc, box_path) = alloc_funcs(macro_args.no_std);
+    let alloc = alloc(macro_args.no_std);
+    let box_path = box_path(macro_args.no_std);
     let make_zst = alloc_zst(&box_path, false);
 
     let tail_layout = tail_layout(&quote! { u8 }, struct_info.tail_field.ty.span());
@@ -694,7 +796,8 @@ fn factory_for_str_arg(macro_args: &MacroArgs, struct_info: &StructInfo) -> Toke
 }
 
 fn factory_for_trait_arg(macro_args: &MacroArgs, struct_info: &StructInfo, trait_path: &Path) -> TokenStream {
-    let (alloc, box_path) = alloc_funcs(macro_args.no_std);
+    let alloc = alloc(macro_args.no_std);
+    let box_path = box_path(macro_args.no_std);
     let make_zst = alloc_zst(&box_path, true);
 
     let header_layout = header_layout(macro_args, struct_info, true);
@@ -762,10 +865,13 @@ fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynResult
     let struct_info = StructInfo::new(&input_struct)?;
 
     let mut factories = Vec::new();
+    let mut iterator_type = None;
     match &struct_info.tail_kind {
         TailKind::Slice(elem_type) => {
             factories.push(factory_for_iter_arg(&macro_args, &struct_info, elem_type));
             factories.push(factory_for_slice_arg(&macro_args, &struct_info, elem_type));
+            factories.push(destructor_with_iter(&macro_args, &struct_info));
+            iterator_type = Some(destructor_iterator_type(&macro_args, &struct_info, elem_type));
         }
 
         TailKind::Str => {
@@ -786,6 +892,8 @@ fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynResult
         impl #impl_generics #struct_name_ident #ty_generics #where_clause {
             #( #factories )*
         }
+
+        #iterator_type
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,11 @@
 //!
 //! // allocate another user, this time using an iterator
 //! let v = vec![0, 1, 2, 3, 4];
-//! let c = User::build(33, v);
+//! let c = User::build(33, v.iter().copied());
 //!
 //! // destructure this user and compare its key to the vector
 //! // this has the advantage of iterating over u8, not &u8 or &mut u8.
-//! let (_age, signing_key) = User::destroy(c);
+//! let (_age, signing_key) = User::destructure(c);
 //! assert!(signing_key.eq(v.into_iter()));
 //! ```
 //! Here's another example, this time using a string as the last field of a struct:
@@ -116,7 +116,7 @@
 //!
 //! The common use case for the #[[`macro@make_dst_factory`]] attribute is to not pass any arguments.
 //! This results in a function called `build` when using a string or dynamic trait as the
-//! last field of the struct, and the functions `build`, `build_from_slice`, and `destroy` when using an array as the last
+//! last field of the struct, and the functions `build`, `build_from_slice`, and `destructure` when using an array as the last
 //! field of the struct.
 //!
 //! The generated functions are private by default and have the following signatures:
@@ -132,7 +132,7 @@
 //! where
 //!     last_field_type: Copy + Sized;
 //!
-//! fn destroy(this: Box<Self>) -> (Type1, Type2, ..., SelfIter);
+//! fn destructure(this: Box<Self>) -> (Type1, Type2, ..., SelfIter);
 //!
 //! // for strings
 //! fn build(field1, field2, ..., last_field: impl AsRef<str>) -> Box<Self>;
@@ -154,22 +154,22 @@
 //! Some examples:
 //!
 //! ```ignore
-//! // The generated functions will be public and called `build`, `build_from_slice`, and `destroy`.
+//! // The generated functions will be public and called `build`, `build_from_slice`, and `destructure`.
 //! #[make_dst_factory(pub)]
 //!
-//! // The generated functions will be private and called `create`, `create_from_slice`, and `destroy`.
+//! // The generated functions will be private and called `create`, `create_from_slice`, and `destructure`.
 //! #[make_dst_factory(create)]
 //!
-//! // The generated functions will be private and called `create`, `create_from_slice`, and `destructure`.
-//! #[make_dst_factory(create, destructor = destructure)]
+//! // The generated functions will be private and called `create`, `create_from_slice`, and `destroy`.
+//! #[make_dst_factory(create, destructurer = destroy)]
 //!
-//! // The generated functions will be public and called `create`, `create_from_slice`, and `destroy`
+//! // The generated functions will be public and called `create`, `create_from_slice`, and `destructure`
 //! #[make_dst_factory(create, pub)]
 //!
-//! // The generated functions will be private, called `create`, `create_from_slice`, and `destroy`, and support the `no_std` environment
+//! // The generated functions will be private, called `create`, `create_from_slice`, and `destructure`, and support the `no_std` environment
 //! #[make_dst_factory(create, no_std)]
 //!
-//! // The generated functions will be private, called `create`, `create_from_slice`, and `destroy`,
+//! // The generated functions will be private, called `create`, `create_from_slice`, and `destructure`,
 //! // support the `no_std` environment, and will have generic types called `X`.
 //! #[make_dst_factory(create, no_std, generic=X)]
 //! ```
@@ -707,7 +707,7 @@ fn destructor_with_iter(macro_args: &MacroArgs, struct_info: &StructInfo) -> Tok
     let header_types = &struct_info.header_types;
 
     let visibility = &macro_args.visibility;
-    let destructor_name = &macro_args.base_destructor_name;
+    let destructor_name = &macro_args.base_destructurer_name;
 
     let tail_field = &struct_info.tail_field_ident;
     let struct_name = &struct_info.struct_name;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,7 +652,7 @@ fn factory_for_iter_arg(macro_args: &MacroArgs, struct_info: &StructInfo, tail_t
     }
 }
 
-fn destructor_iterator_type(macro_args: &MacroArgs, struct_info: &StructInfo, tail_type: &Type) -> TokenStream {
+fn destructurer_iterator_type(macro_args: &MacroArgs, struct_info: &StructInfo, tail_type: &Type) -> TokenStream {
     let dealloc_path = dealloc_path(macro_args.no_std);
 
     let visibility = &macro_args.visibility;
@@ -700,14 +700,14 @@ fn destructor_iterator_type(macro_args: &MacroArgs, struct_info: &StructInfo, ta
     }
 }
 
-fn destructor_with_iter(macro_args: &MacroArgs, struct_info: &StructInfo) -> TokenStream {
+fn destructurer_with_iter(macro_args: &MacroArgs, struct_info: &StructInfo) -> TokenStream {
     let box_path = box_path(macro_args.no_std);
 
     let header_fields = &struct_info.header_field_idents;
     let header_types = &struct_info.header_types;
 
     let visibility = &macro_args.visibility;
-    let destructor_name = &macro_args.base_destructurer_name;
+    let destructurer_name = &macro_args.base_destructurer_name;
 
     let tail_field = &struct_info.tail_field_ident;
     let struct_name = &struct_info.struct_name;
@@ -721,7 +721,7 @@ fn destructor_with_iter(macro_args: &MacroArgs, struct_info: &StructInfo) -> Tok
 
     quote! {
         #[doc = #factory_doc]
-        #visibility fn #destructor_name(
+        #visibility fn #destructurer_name(
             this: #box_path<Self>,
         ) -> ( #( #header_types, )* #iterator_name #ty_generics)
         {
@@ -883,8 +883,8 @@ fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynResult
         TailKind::Slice(elem_type) => {
             factories.push(factory_for_iter_arg(&macro_args, &struct_info, elem_type));
             factories.push(factory_for_slice_arg(&macro_args, &struct_info, elem_type));
-            factories.push(destructor_with_iter(&macro_args, &struct_info));
-            iterator_type = Some(destructor_iterator_type(&macro_args, &struct_info, elem_type));
+            factories.push(destructurer_with_iter(&macro_args, &struct_info));
+            iterator_type = Some(destructurer_iterator_type(&macro_args, &struct_info, elem_type));
         }
 
         TailKind::Str => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@
 //! grammar is:
 //!
 //! ```ignore
-//! #[make_dst_factory(<base_factory_name> [, destructor=<destructor_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, generic=<generic_name>])]
+//! #[make_dst_factory(<base_factory_name> [, destructurer=<destructurer_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, generic=<generic_name>])]
 //! ```
 //!
 //! Some examples:

--- a/src/macro_args.rs
+++ b/src/macro_args.rs
@@ -47,7 +47,7 @@ impl Parse for MacroArgs {
             }
         }
 
-        // Check for destructor = <ident>
+        // Check for destructurer = <ident>
         if input.peek(syn::Ident) {
             let ahead = input.fork();
             let ident = ahead.parse::<Ident>()?;

--- a/src/macro_args.rs
+++ b/src/macro_args.rs
@@ -6,6 +6,9 @@ use syn::{
 
 pub struct MacroArgs {
     pub base_factory_name: Ident,
+    pub base_destructor_name: Ident,
+    /// When `None`, defaults to appending "Iter" to the type's name.
+    pub iterator_name: Option<Ident>,
     pub visibility: Visibility,
     pub no_std: bool,
     pub generic_name: Ident,
@@ -15,6 +18,8 @@ impl Default for MacroArgs {
     fn default() -> Self {
         Self {
             base_factory_name: Ident::new("build", proc_macro2::Span::call_site()),
+            base_destructor_name: Ident::new("destroy", proc_macro2::Span::call_site()),
+            iterator_name: None,
             visibility: Visibility::Inherited,
             no_std: false,
             generic_name: Ident::new("G", proc_macro2::Span::call_site()),
@@ -30,7 +35,7 @@ impl Parse for MacroArgs {
         if input.peek(syn::Ident) {
             let ahead = input.fork();
             let ident = ahead.parse::<Ident>()?;
-            if ident != "no_std" && ident != "pub" && ident != "generic" {
+            if ident != "no_std" && ident != "pub" && ident != "generic" && ident != "destructor" && ident != "iterator" {
                 result.base_factory_name = ident;
 
                 input.advance_to(&ahead);
@@ -38,6 +43,44 @@ impl Parse for MacroArgs {
                     _ = input
                         .parse::<Token![,]>()
                         .map_err(|_ignored| input.error("Expected comma after factory name"))?;
+                }
+            }
+        }
+
+        // Check for destructor = <ident>
+        if input.peek(syn::Ident) {
+            let ahead = input.fork();
+            let ident = ahead.parse::<Ident>()?;
+            if ident == "destructor" {
+                input.advance_to(&ahead);
+                _ = input.parse::<Token![=]>()?;
+                result.base_destructor_name = input
+                    .parse::<Ident>()
+                    .map_err(|_ignored| input.error("Expected identifier after `destructor=`"))?;
+                if !input.is_empty() {
+                    _ = input
+                        .parse::<Token![,]>()
+                        .map_err(|_ignored| input.error("Expected comma after destructor name"))?;
+                }
+            }
+        }
+
+        // Check for iterator = <ident>
+        if input.peek(syn::Ident) {
+            let ahead = input.fork();
+            let ident = ahead.parse::<Ident>()?;
+            if ident == "iterator" {
+                input.advance_to(&ahead);
+                _ = input.parse::<Token![=]>()?;
+                result.iterator_name = Some(
+                    input
+                        .parse::<Ident>()
+                        .map_err(|_ignored| input.error("Expected identifier after `iterator=`"))?,
+                );
+                if !input.is_empty() {
+                    _ = input
+                        .parse::<Token![,]>()
+                        .map_err(|_ignored| input.error("Expected comma after iterator name"))?;
                 }
             }
         }

--- a/src/macro_args.rs
+++ b/src/macro_args.rs
@@ -6,7 +6,7 @@ use syn::{
 
 pub struct MacroArgs {
     pub base_factory_name: Ident,
-    pub base_destructor_name: Ident,
+    pub base_destructurer_name: Ident,
     /// When `None`, defaults to appending "Iter" to the type's name.
     pub iterator_name: Option<Ident>,
     pub visibility: Visibility,
@@ -18,7 +18,7 @@ impl Default for MacroArgs {
     fn default() -> Self {
         Self {
             base_factory_name: Ident::new("build", proc_macro2::Span::call_site()),
-            base_destructor_name: Ident::new("destroy", proc_macro2::Span::call_site()),
+            base_destructurer_name: Ident::new("destructure", proc_macro2::Span::call_site()),
             iterator_name: None,
             visibility: Visibility::Inherited,
             no_std: false,
@@ -35,7 +35,7 @@ impl Parse for MacroArgs {
         if input.peek(syn::Ident) {
             let ahead = input.fork();
             let ident = ahead.parse::<Ident>()?;
-            if ident != "no_std" && ident != "pub" && ident != "generic" && ident != "destructor" && ident != "iterator" {
+            if ident != "no_std" && ident != "pub" && ident != "generic" && ident != "destructurer" && ident != "iterator" {
                 result.base_factory_name = ident;
 
                 input.advance_to(&ahead);
@@ -51,16 +51,16 @@ impl Parse for MacroArgs {
         if input.peek(syn::Ident) {
             let ahead = input.fork();
             let ident = ahead.parse::<Ident>()?;
-            if ident == "destructor" {
+            if ident == "destructurer" {
                 input.advance_to(&ahead);
                 _ = input.parse::<Token![=]>()?;
-                result.base_destructor_name = input
+                result.base_destructurer_name = input
                     .parse::<Ident>()
-                    .map_err(|_ignored| input.error("Expected identifier after `destructor=`"))?;
+                    .map_err(|_ignored| input.error("Expected identifier after `destructurer=`"))?;
                 if !input.is_empty() {
                     _ = input
                         .parse::<Token![,]>()
-                        .map_err(|_ignored| input.error("Expected comma after destructor name"))?;
+                        .map_err(|_ignored| input.error("Expected comma after destructurer name"))?;
                 }
             }
         }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -53,7 +53,7 @@ fn long_form_str_usage() {
     }
 }
 
-#[make_dst_factory(basic_slice_builder, generic = M)]
+#[make_dst_factory(basic_slice_builder, destructor = basic_slice_destructor, iterator = IterForBasicSlice, generic = M)]
 struct BasicSliceStruct<T> {
     id: usize,
     elements: [T],
@@ -68,6 +68,10 @@ fn basic_slice_usage() {
 
         assert_eq!(instance.id, i);
         assert_eq!(&instance.elements, v.as_slice());
+
+        let (id, elements_iter): (usize, IterForBasicSlice<char>) = BasicSliceStruct::basic_slice_destructor(instance);
+        assert_eq!(id, i);
+        assert!(elements_iter.eq(v));
     }
 }
 
@@ -131,6 +135,9 @@ fn only_slice_dst_field() {
     let char_data: &[char] = &['x', 'y', 'z'];
     let instance: Box<OnlySliceField<char>> = OnlySliceField::build_only_slice_from_slice(char_data);
     assert_eq!(&instance.items_data, char_data);
+    // notice that this is not a tuple in this case when the slice is the only field
+    let items_iter: OnlySliceFieldIter<char> = OnlySliceField::destroy(instance);
+    assert!(items_iter.eq(char_data.iter().copied()));
 }
 
 #[make_dst_factory]
@@ -223,6 +230,10 @@ fn struct_from_iter_where_clause() {
     let instance: Box<WhereClauseStruct<u8>> = WhereClauseStruct::build_where_clause_from_slice(5u8, u8_items);
     assert_eq!(instance.fixed_item, 5u8);
     assert_eq!(&instance.variable_items, u8_items);
+
+    let (fixed_item, variable_items_iter) = WhereClauseStruct::destroy(instance);
+    assert_eq!(fixed_item, 5u8);
+    assert!(variable_items_iter.eq(u8_items.iter().copied()));
 }
 
 #[derive(Debug)]
@@ -247,6 +258,8 @@ fn empty_dst_slice_data() {
     assert_eq!(instance.id, 0);
     assert!(instance.elements.is_empty());
     assert_eq!(&instance.elements, empty_u16_data);
+    let (_, mut elements_iter) = BasicSliceStruct::basic_slice_destructor(instance);
+    assert_eq!(elements_iter.next(), None);
 }
 
 #[test]
@@ -269,6 +282,13 @@ fn zst_slice_dst() {
     let instance: Box<ZstSliceStruct> = ZstSliceStruct::build_zst_slice_from_slice(0xAB_CDEF, zst_data_slice);
     assert_eq!(instance.a, 0xAB_CDEF);
     assert_eq!(instance.unit_slice.len(), 4);
+    let (a, mut unit_iter) = ZstSliceStruct::destroy(instance);
+    assert_eq!(a, 0xAB_CDEF);
+    assert_eq!(unit_iter.next(), Some(()));
+    assert_eq!(unit_iter.next(), Some(()));
+    assert_eq!(unit_iter.next(), Some(()));
+    assert_eq!(unit_iter.next(), Some(()));
+    assert_eq!(unit_iter.next(), None);
 }
 
 // Iterator that incorrectly reports its length via ExactSizeIterator
@@ -392,6 +412,10 @@ fn aligned_slice_struct() {
 
     assert_eq!(instance.data, 42);
     assert_eq!(instance.tail[0], Align32 { payload: 0xDEA_DBEEF });
+
+    let (data, mut tail_iter) = AlignedSliceStruct::destroy(instance);
+    assert_eq!(data, 42);
+    assert_eq!(tail_iter.next(), Some(Align32 { payload: 0xDEA_DBEEF }));
 }
 
 #[make_dst_factory]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -443,6 +443,44 @@ fn aligned_trait_struct() {
     assert_eq!(instance.tail.get_number(), 100);
 }
 
+#[make_dst_factory(destructurer = custom_destructure)]
+struct CustomDestructureStruct<T> {
+    id: usize,
+    elements: [T],
+}
+
+#[test]
+fn custom_destructure_usage() {
+    for i in 0..64 {
+        let v = vec!['*'; i];
+
+        let instance: Box<CustomDestructureStruct<char>> = CustomDestructureStruct::build_from_slice(i, v.as_slice());
+
+        let (id, elements_iter): (usize, CustomDestructureStructIter<char>) = CustomDestructureStruct::custom_destructure(instance);
+        assert_eq!(id, i);
+        assert!(elements_iter.eq(v));
+    }
+}
+
+#[make_dst_factory(iterator = MyIter)]
+struct CustomIteratorStruct<T> {
+    id: usize,
+    elements: [T],
+}
+
+#[test]
+fn custom_iterator_usage() {
+    for i in 0..64 {
+        let v = vec!['*'; i];
+
+        let instance: Box<CustomIteratorStruct<char>> = CustomIteratorStruct::build_from_slice(i, v.as_slice());
+
+        let (id, elements_iter): (usize, MyIter<char>) = CustomIteratorStruct::destructure(instance);
+        assert_eq!(id, i);
+        assert!(elements_iter.eq(v));
+    }
+}
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn no_std() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -53,7 +53,7 @@ fn long_form_str_usage() {
     }
 }
 
-#[make_dst_factory(basic_slice_builder, destructor = basic_slice_destructor, iterator = IterForBasicSlice, generic = M)]
+#[make_dst_factory(basic_slice_builder, destructurer = basic_slice_destructure, iterator = IterForBasicSlice, generic = M)]
 struct BasicSliceStruct<T> {
     id: usize,
     elements: [T],
@@ -69,7 +69,7 @@ fn basic_slice_usage() {
         assert_eq!(instance.id, i);
         assert_eq!(&instance.elements, v.as_slice());
 
-        let (id, elements_iter): (usize, IterForBasicSlice<char>) = BasicSliceStruct::basic_slice_destructor(instance);
+        let (id, elements_iter): (usize, IterForBasicSlice<char>) = BasicSliceStruct::basic_slice_destructure(instance);
         assert_eq!(id, i);
         assert!(elements_iter.eq(v));
     }
@@ -136,7 +136,7 @@ fn only_slice_dst_field() {
     let instance: Box<OnlySliceField<char>> = OnlySliceField::build_only_slice_from_slice(char_data);
     assert_eq!(&instance.items_data, char_data);
     // notice that this is not a tuple in this case when the slice is the only field
-    let items_iter: OnlySliceFieldIter<char> = OnlySliceField::destroy(instance);
+    let items_iter: OnlySliceFieldIter<char> = OnlySliceField::destructure(instance);
     assert!(items_iter.eq(char_data.iter().copied()));
 }
 
@@ -231,7 +231,7 @@ fn struct_from_iter_where_clause() {
     assert_eq!(instance.fixed_item, 5u8);
     assert_eq!(&instance.variable_items, u8_items);
 
-    let (fixed_item, variable_items_iter) = WhereClauseStruct::destroy(instance);
+    let (fixed_item, variable_items_iter) = WhereClauseStruct::destructure(instance);
     assert_eq!(fixed_item, 5u8);
     assert!(variable_items_iter.eq(u8_items.iter().copied()));
 }
@@ -258,7 +258,7 @@ fn empty_dst_slice_data() {
     assert_eq!(instance.id, 0);
     assert!(instance.elements.is_empty());
     assert_eq!(&instance.elements, empty_u16_data);
-    let (_, mut elements_iter) = BasicSliceStruct::basic_slice_destructor(instance);
+    let (_, mut elements_iter) = BasicSliceStruct::basic_slice_destructure(instance);
     assert_eq!(elements_iter.next(), None);
 }
 
@@ -282,7 +282,7 @@ fn zst_slice_dst() {
     let instance: Box<ZstSliceStruct> = ZstSliceStruct::build_zst_slice_from_slice(0xAB_CDEF, zst_data_slice);
     assert_eq!(instance.a, 0xAB_CDEF);
     assert_eq!(instance.unit_slice.len(), 4);
-    let (a, mut unit_iter) = ZstSliceStruct::destroy(instance);
+    let (a, mut unit_iter) = ZstSliceStruct::destructure(instance);
     assert_eq!(a, 0xAB_CDEF);
     assert_eq!(unit_iter.next(), Some(()));
     assert_eq!(unit_iter.next(), Some(()));
@@ -413,7 +413,7 @@ fn aligned_slice_struct() {
     assert_eq!(instance.data, 42);
     assert_eq!(instance.tail[0], Align32 { payload: 0xDEA_DBEEF });
 
-    let (data, mut tail_iter) = AlignedSliceStruct::destroy(instance);
+    let (data, mut tail_iter) = AlignedSliceStruct::destructure(instance);
     assert_eq!(data, 42);
     assert_eq!(tail_iter.next(), Some(Align32 { payload: 0xDEA_DBEEF }));
 }


### PR DESCRIPTION
Closes #1 

The factory macro now generates an Iterator structure (with a customizable name; default is `{struct}Iter`) which is returned by the newly-generated `destroy` function (also customizable).

The iterator structure is responsible for freeing the `Box` it originated from in its drop implementation, preventing the memory from being leaked.

`alloc_funcs` and `guard_type` were split up so I could access `dealloc_path` and `box_path` independently.

All slice-related tests were updated to include some destructuring, to show that they all remain functional.