### PR TITLE
Add trait impls, Box-to-Arc/Rc conversions, and serde optimizations

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,4 +1,4 @@
-45
+48
 _arc
 _rc
 boolean
@@ -9,6 +9,8 @@ codecov
 config
 deps
 deserializes
+deserializer
+deserializing
 Deserializing
 DST
 DSTs
@@ -21,6 +23,7 @@ github
 init
 io
 Iter
+lexicographically
 metadata
 MSRV
 proc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 0.6.0 - 2026-03-14
 
-- Add support for factories that return Arc<T> and Rc<T>, in addition to the existing Box<T>
+- Add support for factories that return Arc<T> and Rc<T>, in addition to the existing Box<T>.
+
+- Add support to implement the Debug, Eq, PartialEq, and Hash traits for the DST.
+
+- Fix serde use in no_std.
+
+- Speed up deserialization for string tails by often avoiding an intermediate alloc during deserialization.
 
 ## 0.5.0 - 2026-02-18
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,18 @@
 
 * [Summary](#summary)
 * [Why Should You Care?](#why-should-you-care)
+* [Where to Use DSTs?](#where-to-use-dsts)
 * [Examples](#examples)
-* [Attribute Features](#attribute-features)
-* [Other Features](#other-features)
+* [Smart Pointers](#smart-pointers)
+* [Trait Implementations](#trait-implementations)
 * [Serde Support](#serde-support)
+* [Other Features](#other-features)
 * [Error Conditions](#error-conditions)
-* [Acknowledgments](#acknowledgements)
+* [Acknowledgments](#acknowledgments)
 
 ## Summary
 
 <!-- cargo-rdme start -->
-
 
 Rich support to safely create instances of [Dynamically Sized Types](https://doc.rust-lang.org/reference/dynamically-sized-types.html).
 
@@ -37,7 +38,7 @@ instances of such types. This is where this crate comes in.
 You can apply the #[[`macro@make_dst_factory`]] attribute to your DST structs, which causes factory
 functions to be produced that let you easily and safely create instances of your DSTs.
 
-### Why Should You Care?
+## Why Should You Care?
 
 Dynamically sized types aren't for everyone. You can't use them as local variables
 or put them in arrays or vectors, so they can be inconvenient to use. However, their value
@@ -46,7 +47,7 @@ reduce the memory footprint of your application. If you're building graphs, tree
 dynamic data structures, you can often leverage DSTs to keep your individual nodes smaller
 and more efficient.
 
-### Where to Use DSTs?
+## Where to Use DSTs?
 
 It can be hard or tedious to discover where in your codebase there re opportunities to use DSTs.
 You can give the following prompt to your favorite AI to have it find candidate structs that
@@ -98,7 +99,7 @@ Output format per candidate:
  Savings: 1 allocation per instance × volume
 ```
 
-### Examples
+## Examples
 
 Here's an example using an array as the last field of a struct:
 
@@ -187,14 +188,14 @@ Because DSTs don't have a known size at compile time, you can't store them on th
 and you can't pass them by value. As a result of these constraints, the factory functions
 return smart-pointer-wrapped instances of the structs.
 
-### Smart Pointers
+## Smart Pointers
 
 The macro generates factory functions for three smart pointer types, each constructed
 in a **single allocation**:
 
 | Pointer | Factory suffix | Use case |
 |---------|---------------|----------|
-| [`Box<T>`] | *(none)* | Unique ownership (default) |
+| [`Box<T>`] | *(none)* | Unique ownership |
 | [`Arc<T>`](std::sync::Arc) | `_arc` | Shared ownership, thread-safe (atomic refcount) |
 | [`Rc<T>`](std::rc::Rc) | `_rc` | Shared ownership, single-threaded (non-atomic refcount) |
 
@@ -221,7 +222,16 @@ assert_eq!(&clone.name, "Bob");
 let local: Rc<User> = User::build_rc(33, "Carol");
 let clone = Rc::clone(&local);
 assert_eq!(&clone.name, "Carol");
+
+// Convert an existing Box<User> into Arc<User> or Rc<User>
+let boxed: Box<User> = User::build(33, "Dora");
+let shared: Arc<User> = User::into_arc(boxed);
+assert_eq!(&shared.name, "Dora");
 ```
+
+In addition to the factory methods, the macro always generates `into_arc` and `into_rc`
+associated functions that convert a `Box<Self>` into `Arc<Self>` or `Rc<Self>` while
+preserving the inline DST layout.
 
 ### Attribute Features
 
@@ -264,6 +274,9 @@ where
 
 fn destructure(this: Box<Self>) -> (Type1, Type2, ..., SelfIter);
 
+fn into_arc(this: Box<Self>) -> Arc<Self>;
+fn into_rc(this: Box<Self>) -> Rc<Self>;
+
 // for strings
 fn build(field1, field2, ..., last_field: impl AsRef<str>) -> Box<Self>;
 fn build_arc(field1, field2, ..., last_field: impl AsRef<str>) -> Arc<Self>;
@@ -288,7 +301,7 @@ visibility, and whether to generate code for the `no_std` environment. The gener
 grammar is:
 
 ```rust
-#[make_dst_factory(<base_factory_name> [, destructurer=<destructurer_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, deserialize] [, clone] [, generic=<generic_name>])]
+#[make_dst_factory(<base_factory_name> [, destructurer=<destructurer_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, deserialize] [, clone] [, debug] [, eq] [, ord] [, hash] [, generic=<generic_name>])]
 ```
 
 Some examples:
@@ -315,24 +328,30 @@ Some examples:
 #[make_dst_factory(create, no_std, generic=X)]
 ```
 
-### Other Features
+## Trait Implementations
 
-You can use the #[[`macro@make_dst_factory`]] attribute on structs with the normal Rust
-representation or C representation (`#[repr(C)]`), with any padding and alignment
-specification. See the Rust reference on [Type Layout](https://doc.rust-lang.org/reference/type-layout.html)
-for more details.
+Rust's standard `#[derive(...)]` doesn't work for DST structs because the derive macros
+can't handle unsized types. The #[[`macro@make_dst_factory`]] attribute provides flags to
+generate these trait implementations:
 
-### Clone Support
+| Flag | Trait(s) generated | Notes |
+|------|-------------------|-------|
+| `clone` | `Clone` for `Box<T>` | Deep copy via factory function |
+| `debug` | `Debug` for the struct | Named fields or tuple formatting |
+| `eq` | `PartialEq` and `Eq` for the struct | Compares all fields |
+| `ord` | `PartialOrd` and `Ord` for the struct | Compares all fields lexicographically |
+| `hash` | `Hash` for the struct | Hashes all fields |
 
-Because DST structs are unsized, `#[derive(Clone)]` cannot work for `Box<T>` since the
-standard derive doesn't know how to reconstruct the struct. Passing the `clone` flag in
-the attribute generates a `Clone` implementation for `Box<T>` that uses the macro-generated
-factory functions to create a deep copy.
+All flags work with both named and tuple structs, and with `str`, `[T]`, and `dyn Trait`
+tails. For `dyn Trait` tails, the generated where clauses require the trait object to
+implement the relevant trait (e.g. `dyn MyTrait: Debug`). The `clone` flag is the
+exception; it is not supported for `dyn Trait` tails since there is no way to clone
+a concrete type through a trait object reference.
 
 ```rust
 use dst_factory::make_dst_factory;
 
-#[make_dst_factory(clone)]
+#[make_dst_factory(clone, debug, eq, ord, hash)]
 struct Message {
     id: u32,
     text: str,
@@ -340,15 +359,11 @@ struct Message {
 
 let msg = Message::build(1, "hello");
 let cloned = msg.clone();
-assert_eq!(cloned.id, 1);
-assert_eq!(&cloned.text, "hello");
+assert_eq!(msg, cloned);
+assert_eq!(format!("{:?}", &*msg), "Message { id: 1, text: \"hello\" }");
 ```
 
-Clone support works with both named and tuple structs, and with both `str` and `[T]`
-slice tails. It is not supported for `dyn Trait` tails, since there is no way to
-clone the concrete type through a trait object reference.
-
-### Serde Support
+## Serde Support
 
 DST structs work naturally with `#[derive(Serialize)]` from serde, since serialization
 only requires a reference. However, `#[derive(Deserialize)]` cannot work because the
@@ -381,7 +396,7 @@ assert_eq!(restored.id, 1);
 assert_eq!(&restored.text, "hello");
 ```
 
-#### Deserializing into `Arc` and `Rc`
+### Deserializing into `Arc` and `Rc`
 
 Rust's orphan rules prevent implementing `Deserialize` for `Arc<T>` or `Rc<T>` directly
 (they are not `#[fundamental]` like `Box<T>`). Instead, the `deserialize` flag generates
@@ -415,7 +430,14 @@ Serde support works with both named and tuple structs, and with both `str` and `
 slice tails. It is not supported for `dyn Trait` tails, since there is no way to
 reconstruct the concrete type from serialized data.
 
-### Error Conditions
+## Other Features
+
+You can use the #[[`macro@make_dst_factory`]] attribute on structs with the normal Rust
+representation or C representation (`#[repr(C)]`), with any padding and alignment
+specification. See the Rust reference on [Type Layout](https://doc.rust-lang.org/reference/type-layout.html)
+for more details.
+
+## Error Conditions
 
 The #[[`macro@make_dst_factory`]] attribute produces a compile-time error if:
 
@@ -427,7 +449,7 @@ The #[[`macro@make_dst_factory`]] attribute produces a compile-time error if:
 - The `deserialize` flag is used on a struct with a `dyn Trait` tail.
 - The `clone` flag is used on a struct with a `dyn Trait` tail.
 
-### Acknowledgments
+## Acknowledgments
 
 Many thanks to <https://github.com/scottmcm> for his invaluable help getting the factory methods
 in top shape.

--- a/src/box.rs
+++ b/src/box.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Ident, Type};
 
-use crate::common::{StructInfo, box_path, dealloc_path};
+use crate::common::{StructInfo, TailKind, box_path, dealloc_path};
 use crate::macro_args::MacroArgs;
 
 pub fn destructurer_iterator_type(macro_args: &MacroArgs, struct_info: &StructInfo, tail_type: &Type) -> TokenStream {
@@ -117,6 +117,44 @@ pub enum CloneTailKind<'a> {
     Str,
 }
 
+fn merged_where_clause(struct_info: &StructInfo, extra_bounds: Vec<TokenStream>) -> TokenStream {
+    let existing_predicates: Vec<TokenStream> = struct_info
+        .struct_generics
+        .where_clause
+        .as_ref()
+        .map_or_else(Vec::new, |wc| wc.predicates.iter().map(|predicate| quote! { #predicate }).collect());
+
+    let all_bounds: Vec<TokenStream> = existing_predicates.into_iter().chain(extra_bounds).collect();
+
+    if all_bounds.is_empty() {
+        quote! {}
+    } else {
+        quote! { where #( #all_bounds ),* }
+    }
+}
+
+fn header_bounds(struct_info: &StructInfo, bound: &TokenStream) -> Vec<TokenStream> {
+    struct_info
+        .header_fields
+        .iter()
+        .map(|field| {
+            let ty = &field.ty;
+            quote! { #ty: #bound }
+        })
+        .collect()
+}
+
+fn tail_bound(struct_info: &StructInfo, bound: &TokenStream) -> Option<TokenStream> {
+    match &struct_info.tail_kind {
+        TailKind::Slice(elem_type) => Some(quote! { #elem_type: #bound }),
+        TailKind::TraitObject(_) => {
+            let tail_ty = &struct_info.tail_field.ty;
+            Some(quote! { #tail_ty: #bound })
+        }
+        TailKind::Str => None, // str always implements Debug/PartialEq/Eq/Hash
+    }
+}
+
 pub fn gen_clone(macro_args: &MacroArgs, struct_info: &StructInfo, clone_tail: &CloneTailKind) -> TokenStream {
     let struct_name = struct_info.struct_name;
     let box_path = box_path(macro_args.no_std);
@@ -130,7 +168,7 @@ pub fn gen_clone(macro_args: &MacroArgs, struct_info: &StructInfo, clone_tail: &
 
     let tail_ident = &struct_info.tail_field_ident;
 
-    let (factory_call, extra_bounds) = match clone_tail {
+    let (factory_call, mut clone_bounds) = match clone_tail {
         CloneTailKind::Slice(elem_type) => (
             quote! { #struct_name::#factory_name(#( #header_accesses, )* self.#tail_ident.iter().cloned()) },
             vec![quote! { #elem_type: ::core::clone::Clone }],
@@ -141,36 +179,203 @@ pub fn gen_clone(macro_args: &MacroArgs, struct_info: &StructInfo, clone_tail: &
         ),
     };
 
-    let mut clone_bounds: Vec<TokenStream> = struct_info
-        .header_fields
-        .iter()
-        .map(|field| {
-            let ty = &field.ty;
-            quote! { #ty: ::core::clone::Clone }
-        })
-        .collect();
-    clone_bounds.extend(extra_bounds);
-
-    let existing_predicates: Vec<TokenStream> = struct_info
-        .struct_generics
-        .where_clause
-        .as_ref()
-        .map_or_else(Vec::new, |wc| wc.predicates.iter().map(|p| quote! { #p }).collect());
-
-    let all_bounds: Vec<TokenStream> = existing_predicates.into_iter().chain(clone_bounds).collect();
+    let mut prefixed_bounds = header_bounds(struct_info, &quote! { ::core::clone::Clone });
+    prefixed_bounds.append(&mut clone_bounds);
+    clone_bounds = prefixed_bounds;
 
     let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
-
-    let where_clause = if all_bounds.is_empty() {
-        quote! {}
-    } else {
-        quote! { where #( #all_bounds ),* }
-    };
+    let where_clause = merged_where_clause(struct_info, clone_bounds);
 
     quote! {
         impl #impl_generics ::core::clone::Clone for #box_path<#struct_name #ty_generics> #where_clause {
             fn clone(&self) -> Self {
                 #factory_call
+            }
+        }
+    }
+}
+
+pub fn gen_debug(struct_info: &StructInfo) -> TokenStream {
+    let struct_name = struct_info.struct_name;
+    let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
+
+    let mut debug_bounds = header_bounds(struct_info, &quote! { ::core::fmt::Debug });
+    debug_bounds.extend(tail_bound(struct_info, &quote! { ::core::fmt::Debug }));
+    let where_clause = merged_where_clause(struct_info, debug_bounds);
+
+    struct_info.tail_field.ident.as_ref().map_or_else(
+        || {
+            let header_fields: Vec<TokenStream> = struct_info
+                .header_field_idents
+                .iter()
+                .map(|ident| quote! { .field(&self.#ident) })
+                .collect();
+            let tail_ident = &struct_info.tail_field_ident;
+
+            quote! {
+                impl #impl_generics ::core::fmt::Debug for #struct_name #ty_generics #where_clause {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        f.debug_tuple(::core::stringify!(#struct_name))
+                            #( #header_fields )*
+                            .field(&&self.#tail_ident)
+                            .finish()
+                    }
+                }
+            }
+        },
+        |tail_ident| {
+            let header_fields: Vec<TokenStream> = struct_info
+                .header_fields
+                .iter()
+                .filter_map(|field| field.ident.as_ref())
+                .map(|field_ident| {
+                    let field_name = field_ident.to_string();
+                    quote! { .field(#field_name, &self.#field_ident) }
+                })
+                .collect();
+            let tail_name = tail_ident.to_string();
+
+            quote! {
+                impl #impl_generics ::core::fmt::Debug for #struct_name #ty_generics #where_clause {
+                    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                        f.debug_struct(::core::stringify!(#struct_name))
+                            #( #header_fields )*
+                            .field(#tail_name, &&self.#tail_ident)
+                            .finish()
+                    }
+                }
+            }
+        },
+    )
+}
+
+pub fn gen_partial_eq(struct_info: &StructInfo) -> TokenStream {
+    let struct_name = struct_info.struct_name;
+    let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
+
+    let mut partial_eq_bounds = header_bounds(struct_info, &quote! { ::core::cmp::PartialEq });
+    partial_eq_bounds.extend(tail_bound(struct_info, &quote! { ::core::cmp::PartialEq }));
+    let where_clause = merged_where_clause(struct_info, partial_eq_bounds);
+
+    let comparisons: Vec<TokenStream> = struct_info
+        .header_field_idents
+        .iter()
+        .map(|ident| quote! { self.#ident == other.#ident })
+        .chain(::core::iter::once({
+            let tail_ident = &struct_info.tail_field_ident;
+            quote! { self.#tail_ident == other.#tail_ident }
+        }))
+        .collect();
+
+    quote! {
+        impl #impl_generics ::core::cmp::PartialEq for #struct_name #ty_generics #where_clause {
+            fn eq(&self, other: &Self) -> bool {
+                #( #comparisons )&&*
+            }
+        }
+    }
+}
+
+pub fn gen_eq(struct_info: &StructInfo) -> TokenStream {
+    let struct_name = struct_info.struct_name;
+    let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
+
+    let mut eq_bounds = header_bounds(struct_info, &quote! { ::core::cmp::Eq });
+    eq_bounds.extend(tail_bound(struct_info, &quote! { ::core::cmp::Eq }));
+    let where_clause = merged_where_clause(struct_info, eq_bounds);
+
+    quote! {
+        impl #impl_generics ::core::cmp::Eq for #struct_name #ty_generics #where_clause {}
+    }
+}
+
+pub fn gen_hash(struct_info: &StructInfo) -> TokenStream {
+    let struct_name = struct_info.struct_name;
+    let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
+
+    let mut hash_bounds = header_bounds(struct_info, &quote! { ::core::hash::Hash });
+    hash_bounds.extend(tail_bound(struct_info, &quote! { ::core::hash::Hash }));
+    let where_clause = merged_where_clause(struct_info, hash_bounds);
+
+    let header_hashes: Vec<TokenStream> = struct_info
+        .header_field_idents
+        .iter()
+        .map(|ident| quote! { ::core::hash::Hash::hash(&self.#ident, state); })
+        .collect();
+    let tail_ident = &struct_info.tail_field_ident;
+
+    quote! {
+        impl #impl_generics ::core::hash::Hash for #struct_name #ty_generics #where_clause {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: ::core::hash::Hasher,
+            {
+                #( #header_hashes )*
+                ::core::hash::Hash::hash(&self.#tail_ident, state);
+            }
+        }
+    }
+}
+
+pub fn gen_partial_ord(struct_info: &StructInfo) -> TokenStream {
+    let struct_name = struct_info.struct_name;
+    let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
+
+    let mut bounds = header_bounds(struct_info, &quote! { ::core::cmp::PartialOrd });
+    bounds.extend(tail_bound(struct_info, &quote! { ::core::cmp::PartialOrd }));
+    let where_clause = merged_where_clause(struct_info, bounds);
+
+    let field_chains: Vec<TokenStream> = struct_info
+        .header_field_idents
+        .iter()
+        .map(|ident| {
+            quote! {
+                match ::core::cmp::PartialOrd::partial_cmp(&self.#ident, &other.#ident) {
+                    ::core::option::Option::Some(::core::cmp::Ordering::Equal) => {}
+                    ord => return ord,
+                }
+            }
+        })
+        .collect();
+    let tail_ident = &struct_info.tail_field_ident;
+
+    quote! {
+        impl #impl_generics ::core::cmp::PartialOrd for #struct_name #ty_generics #where_clause {
+            fn partial_cmp(&self, other: &Self) -> ::core::option::Option<::core::cmp::Ordering> {
+                #( #field_chains )*
+                ::core::cmp::PartialOrd::partial_cmp(&self.#tail_ident, &other.#tail_ident)
+            }
+        }
+    }
+}
+
+pub fn gen_ord(struct_info: &StructInfo) -> TokenStream {
+    let struct_name = struct_info.struct_name;
+    let (impl_generics, ty_generics, _) = struct_info.struct_generics.split_for_impl();
+
+    let mut bounds = header_bounds(struct_info, &quote! { ::core::cmp::Ord });
+    bounds.extend(tail_bound(struct_info, &quote! { ::core::cmp::Ord }));
+    let where_clause = merged_where_clause(struct_info, bounds);
+
+    let field_chains: Vec<TokenStream> = struct_info
+        .header_field_idents
+        .iter()
+        .map(|ident| {
+            quote! {
+                match ::core::cmp::Ord::cmp(&self.#ident, &other.#ident) {
+                    ::core::cmp::Ordering::Equal => {}
+                    ord => return ord,
+                }
+            }
+        })
+        .collect();
+    let tail_ident = &struct_info.tail_field_ident;
+
+    quote! {
+        impl #impl_generics ::core::cmp::Ord for #struct_name #ty_generics #where_clause {
+            fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+                #( #field_chains )*
+                ::core::cmp::Ord::cmp(&self.#tail_ident, &other.#tail_ident)
             }
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -465,6 +465,65 @@ pub fn rc_alloc_and_init(no_std: bool) -> TokenStream {
     }
 }
 
+fn rebuilt_fat_ptr_from_existing_metadata(struct_info: &StructInfo, data_ptr_ident: &Ident) -> TokenStream {
+    match &struct_info.tail_kind {
+        TailKind::Slice(_) | TailKind::Str => quote! {
+            let (_, metadata): (*mut u8, usize) = ::core::mem::transmute(src_ptr);
+            let fat_ptr = ::core::mem::transmute::<(*mut u8, usize), *mut Self>((#data_ptr_ident, metadata));
+        },
+        TailKind::TraitObject(_) => quote! {
+            let (_, metadata): (*mut u8, *const ()) = ::core::mem::transmute(src_ptr);
+            let fat_ptr = ::core::mem::transmute::<(*mut u8, *const ()), *mut Self>((#data_ptr_ident, metadata));
+        },
+    }
+}
+
+fn gen_into_ptr(macro_args: &MacroArgs, struct_info: &StructInfo, ptr: &PtrKind) -> TokenStream {
+    let visibility = &macro_args.visibility;
+    let box_path = box_path(macro_args.no_std);
+    let ptr_path = &ptr.ptr_path;
+    let alloc_tokens = &ptr.alloc_tokens;
+    let data_ptr_ident = &ptr.data_ptr_ident;
+    let from_raw = &ptr.from_raw;
+    let dealloc_path = dealloc_path(macro_args.no_std);
+    let fat_ptr_rebuild = rebuilt_fat_ptr_from_existing_metadata(struct_info, data_ptr_ident);
+    let fn_name = format_ident!("into{}", ptr.name_suffix);
+    let factory_doc = format!(
+        "Converts a `Box<{name}>` into a single-allocation `{display}<{name}>`.",
+        name = struct_info.struct_name,
+        display = ptr.display_name
+    );
+
+    quote! {
+        #[doc = #factory_doc]
+        #[allow(clippy::transmute_undefined_repr)]
+        #visibility fn #fn_name(this: #box_path<Self>) -> #ptr_path<Self> {
+            let layout = ::core::alloc::Layout::for_value(&*this);
+            let src_ptr = #box_path::into_raw(this);
+
+            unsafe {
+                #alloc_tokens
+                #fat_ptr_rebuild
+
+                ::core::ptr::copy_nonoverlapping(src_ptr as *const u8, fat_ptr as *mut u8, layout.size());
+                if layout.size() != 0 {
+                    #dealloc_path(src_ptr as *mut u8, layout);
+                }
+
+                #from_raw
+            }
+        }
+    }
+}
+
+pub fn gen_into_arc(macro_args: &MacroArgs, struct_info: &StructInfo) -> TokenStream {
+    gen_into_ptr(macro_args, struct_info, &PtrKind::new_arc(macro_args.no_std))
+}
+
+pub fn gen_into_rc(macro_args: &MacroArgs, struct_info: &StructInfo) -> TokenStream {
+    gen_into_ptr(macro_args, struct_info, &PtrKind::new_rc(macro_args.no_std))
+}
+
 // ---------------------------------------------------------------------------
 // Unified factory generation functions
 // ---------------------------------------------------------------------------
@@ -897,11 +956,15 @@ fn gen_serde(
             "deserialize is not supported for DSTs with trait object tails",
         )),
         TailKind::Slice(elem_type) => {
-            let owned_tail_type: Type = syn::parse_quote! { ::std::vec::Vec<#elem_type> };
+            let owned_tail_type: Type = if macro_args.no_std {
+                syn::parse_quote! { ::alloc::vec::Vec<#elem_type> }
+            } else {
+                syn::parse_quote! { ::std::vec::Vec<#elem_type> }
+            };
+            let bp = box_path(macro_args.no_std);
             let factory_name = format_ident!("{}_from_slice", &macro_args.base_factory_name);
-            let box_tokens = serde::gen_deserialize(struct_info, input_struct, &owned_tail_type, &factory_name);
+            let box_tokens = serde::gen_deserialize(struct_info, input_struct, &owned_tail_type, &factory_name, &bp, false);
 
-            // Generate serde functions for Arc and Rc using unified approach
             for ptr in &[PtrKind::new_arc(macro_args.no_std), PtrKind::new_rc(macro_args.no_std)] {
                 let factory = format_ident!("{}{}_from_slice", &macro_args.base_factory_name, ptr.name_suffix);
                 let fn_name = format_ident!("deserialize{}", ptr.name_suffix);
@@ -915,16 +978,30 @@ fn gen_serde(
                     &intermediate_name,
                     &ptr.ptr_path,
                     &macro_args.visibility,
+                    false,
                 ));
             }
 
             Ok(Some(box_tokens))
         }
         TailKind::Str => {
-            let owned_tail_type: Type = syn::parse_quote! { ::std::string::String };
-            let box_tokens = serde::gen_deserialize(struct_info, input_struct, &owned_tail_type, &macro_args.base_factory_name);
+            let (tail_type, borrow_tail): (Type, bool) = if macro_args.no_std {
+                // no_std: use alloc::string::String (Cow requires std serde internals)
+                (syn::parse_quote! { ::alloc::string::String }, false)
+            } else {
+                // std: use Cow<'__borrow, str> to avoid intermediate String allocation
+                (syn::parse_quote! { ::std::borrow::Cow<'__borrow, str> }, true)
+            };
+            let bp = box_path(macro_args.no_std);
+            let box_tokens = serde::gen_deserialize(
+                struct_info,
+                input_struct,
+                &tail_type,
+                &macro_args.base_factory_name,
+                &bp,
+                borrow_tail,
+            );
 
-            // Generate serde functions for Arc and Rc using unified approach
             for ptr in &[PtrKind::new_arc(macro_args.no_std), PtrKind::new_rc(macro_args.no_std)] {
                 let factory = format_ident!("{}{}", &macro_args.base_factory_name, ptr.name_suffix);
                 let fn_name = format_ident!("deserialize{}", ptr.name_suffix);
@@ -932,12 +1009,13 @@ fn gen_serde(
                 factories.push(serde::gen_deserialize_fn(
                     struct_info,
                     input_struct,
-                    &owned_tail_type,
+                    &tail_type,
                     &factory,
                     &fn_name,
                     &intermediate_name,
                     &ptr.ptr_path,
                     &macro_args.visibility,
+                    borrow_tail,
                 ));
             }
 
@@ -953,6 +1031,9 @@ pub fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynRe
 
     let mut factories = Vec::new();
     let mut iterator_type = None;
+
+    factories.push(gen_into_arc(&macro_args, &struct_info));
+    factories.push(gen_into_rc(&macro_args, &struct_info));
 
     // Create PtrKind instances for all three pointer types
     let ptr_kinds = [
@@ -991,6 +1072,12 @@ pub fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynRe
 
     let mut serde_tokens: Option<TokenStream> = None;
     let mut clone_tokens: Option<TokenStream> = None;
+    let mut debug_tokens: Option<TokenStream> = None;
+    let mut partial_eq_tokens: Option<TokenStream> = None;
+    let mut eq_tokens: Option<TokenStream> = None;
+    let mut partial_ord_tokens: Option<TokenStream> = None;
+    let mut ord_tokens: Option<TokenStream> = None;
+    let mut hash_tokens: Option<TokenStream> = None;
 
     if macro_args.deserialize {
         serde_tokens = gen_serde(&macro_args, &struct_info, &input_struct, &mut factories)?;
@@ -1013,6 +1100,24 @@ pub fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynRe
         }
     }
 
+    if macro_args.debug {
+        debug_tokens = Some(r#box::gen_debug(&struct_info));
+    }
+
+    if macro_args.eq {
+        partial_eq_tokens = Some(r#box::gen_partial_eq(&struct_info));
+        eq_tokens = Some(r#box::gen_eq(&struct_info));
+    }
+
+    if macro_args.ord {
+        partial_ord_tokens = Some(r#box::gen_partial_ord(&struct_info));
+        ord_tokens = Some(r#box::gen_ord(&struct_info));
+    }
+
+    if macro_args.hash {
+        hash_tokens = Some(r#box::gen_hash(&struct_info));
+    }
+
     let (impl_generics, ty_generics, where_clause) = struct_info.struct_generics.split_for_impl();
     let struct_name_ident = struct_info.struct_name;
 
@@ -1026,5 +1131,11 @@ pub fn make_dst_factory_impl(attr_args: TokenStream, item: TokenStream) -> SynRe
         #iterator_type
         #serde_tokens
         #clone_tokens
+        #debug_tokens
+        #partial_eq_tokens
+        #eq_tokens
+        #partial_ord_tokens
+        #ord_tokens
+        #hash_tokens
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-//!
 //! Rich support to safely create instances of [Dynamically Sized Types](https://doc.rust-lang.org/reference/dynamically-sized-types.html).
 //!
 //! This crate lets you allocate variable data inline at the end of a struct. If you have a
@@ -15,7 +14,7 @@
 //! You can apply the #[[`macro@make_dst_factory`]] attribute to your DST structs, which causes factory
 //! functions to be produced that let you easily and safely create instances of your DSTs.
 //!
-//! ## Why Should You Care?
+//! # Why Should You Care?
 //!
 //! Dynamically sized types aren't for everyone. You can't use them as local variables
 //! or put them in arrays or vectors, so they can be inconvenient to use. However, their value
@@ -24,7 +23,7 @@
 //! dynamic data structures, you can often leverage DSTs to keep your individual nodes smaller
 //! and more efficient.
 //!
-//! ## Where to Use DSTs?
+//! # Where to Use DSTs?
 //!
 //! It can be hard or tedious to discover where in your codebase there re opportunities to use DSTs.
 //! You can give the following prompt to your favorite AI to have it find candidate structs that
@@ -76,7 +75,7 @@
 //!  Savings: 1 allocation per instance × volume
 //! ```
 //!
-//! ## Examples
+//! # Examples
 //!
 //! Here's an example using an array as the last field of a struct:
 //!
@@ -165,14 +164,14 @@
 //! and you can't pass them by value. As a result of these constraints, the factory functions
 //! return smart-pointer-wrapped instances of the structs.
 //!
-//! ## Smart Pointers
+//! # Smart Pointers
 //!
 //! The macro generates factory functions for three smart pointer types, each constructed
 //! in a **single allocation**:
 //!
 //! | Pointer | Factory suffix | Use case |
 //! |---------|---------------|----------|
-//! | [`Box<T>`] | *(none)* | Unique ownership (default) |
+//! | [`Box<T>`] | *(none)* | Unique ownership |
 //! | [`Arc<T>`](std::sync::Arc) | `_arc` | Shared ownership, thread-safe (atomic refcount) |
 //! | [`Rc<T>`](std::rc::Rc) | `_rc` | Shared ownership, single-threaded (non-atomic refcount) |
 //!
@@ -199,7 +198,16 @@
 //! let local: Rc<User> = User::build_rc(33, "Carol");
 //! let clone = Rc::clone(&local);
 //! assert_eq!(&clone.name, "Carol");
+//!
+//! // Convert an existing Box<User> into Arc<User> or Rc<User>
+//! let boxed: Box<User> = User::build(33, "Dora");
+//! let shared: Arc<User> = User::into_arc(boxed);
+//! assert_eq!(&shared.name, "Dora");
 //! ```
+//!
+//! In addition to the factory methods, the macro always generates `into_arc` and `into_rc`
+//! associated functions that convert a `Box<Self>` into `Arc<Self>` or `Rc<Self>` while
+//! preserving the inline DST layout.
 //!
 //! ## Attribute Features
 //!
@@ -242,6 +250,9 @@
 //!
 //! fn destructure(this: Box<Self>) -> (Type1, Type2, ..., SelfIter);
 //!
+//! fn into_arc(this: Box<Self>) -> Arc<Self>;
+//! fn into_rc(this: Box<Self>) -> Rc<Self>;
+//!
 //! // for strings
 //! fn build(field1, field2, ..., last_field: impl AsRef<str>) -> Box<Self>;
 //! fn build_arc(field1, field2, ..., last_field: impl AsRef<str>) -> Arc<Self>;
@@ -266,7 +277,7 @@
 //! grammar is:
 //!
 //! ```ignore
-//! #[make_dst_factory(<base_factory_name> [, destructurer=<destructurer_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, deserialize] [, clone] [, generic=<generic_name>])]
+//! #[make_dst_factory(<base_factory_name> [, destructurer=<destructurer_name>] [, iterator=<iterator_name>] [, <visibility>] [, no_std] [, deserialize] [, clone] [, debug] [, eq] [, ord] [, hash] [, generic=<generic_name>])]
 //! ```
 //!
 //! Some examples:
@@ -293,24 +304,30 @@
 //! #[make_dst_factory(create, no_std, generic=X)]
 //! ```
 //!
-//! ## Other Features
+//! # Trait Implementations
 //!
-//! You can use the #[[`macro@make_dst_factory`]] attribute on structs with the normal Rust
-//! representation or C representation (`#[repr(C)]`), with any padding and alignment
-//! specification. See the Rust reference on [Type Layout](https://doc.rust-lang.org/reference/type-layout.html)
-//! for more details.
+//! Rust's standard `#[derive(...)]` doesn't work for DST structs because the derive macros
+//! can't handle unsized types. The #[[`macro@make_dst_factory`]] attribute provides flags to
+//! generate these trait implementations:
 //!
-//! ## Clone Support
+//! | Flag | Trait(s) generated | Notes |
+//! |------|-------------------|-------|
+//! | `clone` | `Clone` for `Box<T>` | Deep copy via factory function |
+//! | `debug` | `Debug` for the struct | Named fields or tuple formatting |
+//! | `eq` | `PartialEq` and `Eq` for the struct | Compares all fields |
+//! | `ord` | `PartialOrd` and `Ord` for the struct | Compares all fields lexicographically |
+//! | `hash` | `Hash` for the struct | Hashes all fields |
 //!
-//! Because DST structs are unsized, `#[derive(Clone)]` cannot work for `Box<T>` since the
-//! standard derive doesn't know how to reconstruct the struct. Passing the `clone` flag in
-//! the attribute generates a `Clone` implementation for `Box<T>` that uses the macro-generated
-//! factory functions to create a deep copy.
+//! All flags work with both named and tuple structs, and with `str`, `[T]`, and `dyn Trait`
+//! tails. For `dyn Trait` tails, the generated where clauses require the trait object to
+//! implement the relevant trait (e.g. `dyn MyTrait: Debug`). The `clone` flag is the
+//! exception; it is not supported for `dyn Trait` tails since there is no way to clone
+//! a concrete type through a trait object reference.
 //!
 //! ```rust
 //! use dst_factory::make_dst_factory;
 //!
-//! #[make_dst_factory(clone)]
+//! #[make_dst_factory(clone, debug, eq, ord, hash)]
 //! struct Message {
 //!     id: u32,
 //!     text: str,
@@ -318,15 +335,11 @@
 //!
 //! let msg = Message::build(1, "hello");
 //! let cloned = msg.clone();
-//! assert_eq!(cloned.id, 1);
-//! assert_eq!(&cloned.text, "hello");
+//! assert_eq!(msg, cloned);
+//! assert_eq!(format!("{:?}", &*msg), "Message { id: 1, text: \"hello\" }");
 //! ```
 //!
-//! Clone support works with both named and tuple structs, and with both `str` and `[T]`
-//! slice tails. It is not supported for `dyn Trait` tails, since there is no way to
-//! clone the concrete type through a trait object reference.
-//!
-//! ## Serde Support
+//! # Serde Support
 //!
 //! DST structs work naturally with `#[derive(Serialize)]` from serde, since serialization
 //! only requires a reference. However, `#[derive(Deserialize)]` cannot work because the
@@ -359,7 +372,7 @@
 //! assert_eq!(&restored.text, "hello");
 //! ```
 //!
-//! ### Deserializing into `Arc` and `Rc`
+//! ## Deserializing into `Arc` and `Rc`
 //!
 //! Rust's orphan rules prevent implementing `Deserialize` for `Arc<T>` or `Rc<T>` directly
 //! (they are not `#[fundamental]` like `Box<T>`). Instead, the `deserialize` flag generates
@@ -393,7 +406,14 @@
 //! slice tails. It is not supported for `dyn Trait` tails, since there is no way to
 //! reconstruct the concrete type from serialized data.
 //!
-//! ## Error Conditions
+//! # Other Features
+//!
+//! You can use the #[[`macro@make_dst_factory`]] attribute on structs with the normal Rust
+//! representation or C representation (`#[repr(C)]`), with any padding and alignment
+//! specification. See the Rust reference on [Type Layout](https://doc.rust-lang.org/reference/type-layout.html)
+//! for more details.
+//!
+//! # Error Conditions
 //!
 //! The #[[`macro@make_dst_factory`]] attribute produces a compile-time error if:
 //!
@@ -405,7 +425,7 @@
 //! - The `deserialize` flag is used on a struct with a `dyn Trait` tail.
 //! - The `clone` flag is used on a struct with a `dyn Trait` tail.
 //!
-//! ## Acknowledgments
+//! # Acknowledgments
 //!
 //! Many thanks to <https://github.com/scottmcm> for his invaluable help getting the factory methods
 //! in top shape.

--- a/src/macro_args.rs
+++ b/src/macro_args.rs
@@ -4,6 +4,10 @@ use syn::{
     parse::{Parse, ParseStream, discouraged::Speculative},
 };
 
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "macro options are naturally represented as independent feature flags"
+)]
 pub struct MacroArgs {
     pub base_factory_name: Ident,
     pub base_destructurer_name: Ident,
@@ -13,6 +17,10 @@ pub struct MacroArgs {
     pub no_std: bool,
     pub deserialize: bool,
     pub clone: bool,
+    pub debug: bool,
+    pub eq: bool,
+    pub ord: bool,
+    pub hash: bool,
     pub generic_name: Ident,
 }
 
@@ -26,6 +34,10 @@ impl Default for MacroArgs {
             no_std: false,
             deserialize: false,
             clone: false,
+            debug: false,
+            eq: false,
+            ord: false,
+            hash: false,
             generic_name: Ident::new("G", proc_macro2::Span::call_site()),
         }
     }
@@ -79,6 +91,10 @@ impl Parse for MacroArgs {
             if ident != "no_std"
                 && ident != "deserialize"
                 && ident != "clone"
+                && ident != "debug"
+                && ident != "eq"
+                && ident != "ord"
+                && ident != "hash"
                 && ident != "pub"
                 && ident != "generic"
                 && ident != "destructurer"
@@ -117,6 +133,26 @@ impl Parse for MacroArgs {
         if try_consume_keyword(input, "clone")? {
             result.clone = true;
             consume_trailing_comma(input, "clone")?;
+        }
+
+        if try_consume_keyword(input, "debug")? {
+            result.debug = true;
+            consume_trailing_comma(input, "debug")?;
+        }
+
+        if try_consume_keyword(input, "eq")? {
+            result.eq = true;
+            consume_trailing_comma(input, "eq")?;
+        }
+
+        if try_consume_keyword(input, "ord")? {
+            result.ord = true;
+            consume_trailing_comma(input, "ord")?;
+        }
+
+        if try_consume_keyword(input, "hash")? {
+            result.hash = true;
+            consume_trailing_comma(input, "hash")?;
         }
 
         if let Some(name) = parse_keyword_value(input, "generic")? {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,7 +12,17 @@ use crate::common::StructInfo;
 /// so serde's full attribute vocabulary works naturally.
 ///
 /// The caller must reject trait object tails before invoking this function.
-pub fn gen_deserialize(struct_info: &StructInfo, input_struct: &ItemStruct, owned_tail_type: &Type, factory_name: &Ident) -> TokenStream {
+/// For `str` tails, the shadow struct uses `Cow<'de, str>` instead of `String` to avoid
+/// an intermediate allocation when the deserializer supports borrowing (e.g. `serde_json`
+/// deserializing from `&str`).
+pub fn gen_deserialize(
+    struct_info: &StructInfo,
+    input_struct: &ItemStruct,
+    owned_tail_type: &Type,
+    factory_name: &Ident,
+    box_path: &TokenStream,
+    borrow_tail: bool,
+) -> TokenStream {
     let struct_name = struct_info.struct_name;
     let shadow_name = format_ident!("__{}Intermediate", struct_name);
     let (_impl_generics, ty_generics, where_clause) = struct_info.struct_generics.split_for_impl();
@@ -22,9 +32,21 @@ pub fn gen_deserialize(struct_info: &StructInfo, input_struct: &ItemStruct, owne
     shadow.vis = syn::Visibility::Inherited;
     shadow.attrs.retain(|attr| attr.path().is_ident("serde"));
 
-    if let Some(tail) = shadow.fields.iter_mut().last() {
-        tail.ty = owned_tail_type.clone();
+    let tail = shadow.fields.iter_mut().last().expect("struct has no fields");
+    tail.ty = owned_tail_type.clone();
+    if borrow_tail {
+        tail.attrs.push(syn::parse_quote!(#[serde(borrow)]));
     }
+
+    if borrow_tail {
+        shadow.generics.params.insert(0, syn::parse_quote!('__borrow));
+    }
+
+    let shadow_ty = if borrow_tail {
+        quote! { #shadow_name<'de> }
+    } else {
+        quote! { #shadow_name }
+    };
 
     let header_accesses: Vec<TokenStream> = struct_info
         .header_field_idents
@@ -38,12 +60,12 @@ pub fn gen_deserialize(struct_info: &StructInfo, input_struct: &ItemStruct, owne
             #[derive(::serde::Deserialize)]
             #shadow
 
-            impl<'de> ::serde::Deserialize<'de> for ::std::boxed::Box<#struct_name #ty_generics> #where_clause {
+            impl<'de> ::serde::Deserialize<'de> for #box_path<#struct_name #ty_generics> #where_clause {
                 fn deserialize<D>(deserializer: D) -> ::core::result::Result<Self, D::Error>
                 where
                     D: ::serde::Deserializer<'de>,
                 {
-                    let intermediate = <#shadow_name as ::serde::Deserialize>::deserialize(deserializer)?;
+                    let intermediate = <#shadow_ty as ::serde::Deserialize>::deserialize(deserializer)?;
                     ::core::result::Result::Ok(#struct_name::#factory_name(#( #header_accesses, )* &intermediate.#tail_ident))
                 }
             }
@@ -68,6 +90,7 @@ pub fn gen_deserialize_fn(
     shadow_suffix: &str,
     wrapper_path: &TokenStream,
     visibility: &syn::Visibility,
+    borrow_tail: bool,
 ) -> TokenStream {
     let struct_name = struct_info.struct_name;
     let shadow_name = format_ident!("__{struct_name}{shadow_suffix}");
@@ -78,9 +101,21 @@ pub fn gen_deserialize_fn(
     shadow.vis = syn::Visibility::Inherited;
     shadow.attrs.retain(|attr| attr.path().is_ident("serde"));
 
-    if let Some(tail) = shadow.fields.iter_mut().last() {
-        tail.ty = owned_tail_type.clone();
+    let tail = shadow.fields.iter_mut().last().expect("struct has no fields");
+    tail.ty = owned_tail_type.clone();
+    if borrow_tail {
+        tail.attrs.push(syn::parse_quote!(#[serde(borrow)]));
     }
+
+    if borrow_tail {
+        shadow.generics.params.insert(0, syn::parse_quote!('__borrow));
+    }
+
+    let shadow_ty = if borrow_tail {
+        quote! { #shadow_name<'de> }
+    } else {
+        quote! { #shadow_name }
+    };
 
     let header_accesses: Vec<TokenStream> = struct_info
         .header_field_idents
@@ -102,7 +137,7 @@ pub fn gen_deserialize_fn(
             #[derive(::serde::Deserialize)]
             #shadow
 
-            let intermediate = <#shadow_name as ::serde::Deserialize>::deserialize(deserializer)?;
+            let intermediate = <#shadow_ty as ::serde::Deserialize>::deserialize(deserializer)?;
             ::core::result::Result::Ok(Self::#factory_name(#( #header_accesses, )* &intermediate.#tail_ident))
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,6 +2,12 @@ use core::fmt::Debug;
 use core::ptr::read_unaligned;
 use dst_factory::make_dst_factory;
 
+fn hash_value<T: core::hash::Hash + ?Sized>(value: &T) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    core::hash::Hash::hash(value, &mut hasher);
+    core::hash::Hasher::finish(&hasher)
+}
+
 #[make_dst_factory(basic_str_builder)]
 struct BasicStrStruct {
     id: usize,
@@ -518,6 +524,7 @@ fn custom_iterator_usage() {
 fn no_std() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/no_std.rs");
+    t.pass("tests/ui/no_std_serde.rs");
 }
 
 #[test]
@@ -544,6 +551,10 @@ fn error_paths() {
     t.compile_fail("tests/ui/no_comma_after_iterator.rs");
     t.compile_fail("tests/ui/clone_trait_object.rs");
     t.compile_fail("tests/ui/no_comma_after_clone.rs");
+    t.compile_fail("tests/ui/no_comma_after_debug.rs");
+    t.compile_fail("tests/ui/no_comma_after_eq.rs");
+    t.compile_fail("tests/ui/no_comma_after_ord.rs");
+    t.compile_fail("tests/ui/no_comma_after_hash.rs");
 }
 
 // --- Clone tests ---
@@ -615,6 +626,157 @@ fn clone_only_slice_field() {
     let original: Box<CloneableOnlySlice> = CloneableOnlySlice::build_from_slice(&[10, 20, 30]);
     let cloned = original.clone();
     assert_eq!(&original.items, &cloned.items);
+}
+
+#[make_dst_factory(clone, debug, eq, ord, hash)]
+struct DebugEqHashStr {
+    id: u32,
+    text: str,
+}
+
+#[make_dst_factory(debug, eq, ord, hash)]
+struct DebugEqHashSliceTuple<T>(u8, [T])
+where
+    T: Debug + Eq + Ord + core::hash::Hash;
+
+#[test]
+fn debug_impl_for_named_str_dst() {
+    let instance: Box<DebugEqHashStr> = DebugEqHashStr::build(7, "hello debug");
+    assert_eq!(format!("{:?}", &*instance), "DebugEqHashStr { id: 7, text: \"hello debug\" }");
+}
+
+#[test]
+fn debug_impl_for_tuple_slice_dst() {
+    let instance: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(3, &[10, 20, 30]);
+    assert_eq!(format!("{:?}", &*instance), "DebugEqHashSliceTuple(3, [10, 20, 30])");
+}
+
+#[test]
+fn eq_impl_for_dsts() {
+    let original: Box<DebugEqHashStr> = DebugEqHashStr::build(9, "same");
+    let cloned = original.clone();
+    let different: Box<DebugEqHashStr> = DebugEqHashStr::build(9, "different");
+    assert_eq!(original, cloned);
+    assert_ne!(original, different);
+
+    let left: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(1, &[1, 2, 3]);
+    let right: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(1, &[1, 2, 3]);
+    let other: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(1, &[1, 2, 4]);
+    assert_eq!(left, right);
+    assert_ne!(left, other);
+}
+
+#[test]
+fn hash_impl_for_dsts() {
+    let first_str: Box<DebugEqHashStr> = DebugEqHashStr::build(5, "hash me");
+    let same_str: Box<DebugEqHashStr> = DebugEqHashStr::build(5, "hash me");
+    let different_str: Box<DebugEqHashStr> = DebugEqHashStr::build(5, "hash someone else");
+    assert_eq!(hash_value(&*first_str), hash_value(&*same_str));
+    assert_ne!(hash_value(&*first_str), hash_value(&*different_str));
+
+    let first_slice: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(8, &[4, 5, 6]);
+    let same_slice: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(8, &[4, 5, 6]);
+    let different_slice: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(8, &[4, 5, 7]);
+    assert_eq!(hash_value(&*first_slice), hash_value(&*same_slice));
+    assert_ne!(hash_value(&*first_slice), hash_value(&*different_slice));
+}
+
+#[test]
+fn ord_impl_for_dsts() {
+    let apple: Box<DebugEqHashStr> = DebugEqHashStr::build(1, "apple");
+    let banana: Box<DebugEqHashStr> = DebugEqHashStr::build(1, "banana");
+    let higher_id: Box<DebugEqHashStr> = DebugEqHashStr::build(2, "apple");
+    assert!(apple < banana); // same id, "apple" < "banana"
+    assert!(apple < higher_id); // id 1 < id 2
+    assert!(banana < higher_id); // id 1 < id 2
+
+    let small: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(1, &[1, 2, 3]);
+    let larger_tail: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(1, &[1, 2, 4]);
+    let larger_header: Box<DebugEqHashSliceTuple<u32>> = DebugEqHashSliceTuple::build_from_slice(2, &[1, 2, 3]);
+    assert!(small < larger_tail); // same header, [1,2,3] < [1,2,4]
+    assert!(small < larger_header); // header 1 < 2
+}
+
+// Trait object with Debug — exercises tail_bound's TraitObject arm
+#[expect(dead_code, reason = "exists to test Debug on trait object DSTs")]
+trait DebugProducer: Debug {
+    fn get_value(&self) -> u32;
+}
+
+#[derive(Debug)]
+struct DebugFortyTwo;
+impl DebugProducer for DebugFortyTwo {
+    fn get_value(&self) -> u32 {
+        42
+    }
+}
+
+#[make_dst_factory(debug)]
+struct DebugTraitNode {
+    id: u32,
+    producer: dyn DebugProducer,
+}
+
+#[test]
+fn debug_impl_for_trait_object_dst() {
+    let instance: Box<DebugTraitNode> = DebugTraitNode::build(7, DebugFortyTwo);
+    let debug_str = format!("{:?}", &*instance);
+    assert!(debug_str.contains("DebugTraitNode"));
+    assert!(debug_str.contains("id"));
+    assert!(debug_str.contains("DebugFortyTwo"));
+}
+
+#[test]
+fn into_arc_from_box_str() {
+    let boxed: Box<BasicStrStruct> = BasicStrStruct::basic_str_builder(11, "shared box");
+    let shared: Arc<BasicStrStruct> = BasicStrStruct::into_arc(boxed);
+    assert_eq!(shared.id, 11);
+    assert_eq!(&shared.text_data, "shared box");
+    assert_eq!(Arc::strong_count(&shared), 1);
+}
+
+#[test]
+fn into_rc_from_box_slice() {
+    let boxed: Box<BasicSliceStruct<u32>> = BasicSliceStruct::basic_slice_builder(12, [1, 2, 3, 4]);
+    let local: Rc<BasicSliceStruct<u32>> = BasicSliceStruct::into_rc(boxed);
+    assert_eq!(local.id, 12);
+    assert_eq!(&local.elements, &[1, 2, 3, 4]);
+    assert_eq!(Rc::strong_count(&local), 1);
+}
+
+#[test]
+fn into_arc_handles_zero_sized_box_allocation() {
+    let boxed: Box<OnlyStrField> = OnlyStrField::build_only_str("");
+    let shared: Arc<OnlyStrField> = OnlyStrField::into_arc(boxed);
+    assert_eq!(&shared.content, "");
+    assert_eq!(Arc::strong_count(&shared), 1);
+}
+
+#[test]
+fn into_arc_trait_object_preserves_drop_semantics() {
+    TRAIT_DROP_COUNT.store(0, Ordering::Relaxed);
+
+    {
+        let boxed: Box<GreeterNode> = GreeterNode::build(
+            2,
+            HelloGreeter {
+                _data: "converted".to_string(),
+            },
+        );
+        let shared: Arc<GreeterNode> = GreeterNode::into_arc(boxed);
+        assert_eq!(shared.id, 2);
+        assert_eq!(shared.greeter.greet(), "hello");
+    }
+
+    assert_eq!(TRAIT_DROP_COUNT.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn into_rc_trait_object_preserves_behavior() {
+    let boxed: Box<Node> = Node::build(6, FortyTwoProducer {});
+    let local: Rc<Node> = Node::into_rc(boxed);
+    assert_eq!(local.count, 6);
+    assert_eq!(local.producer.get_number(), 42);
 }
 
 // --- ExactSizeIterator and Debug tests ---

--- a/tests/ui/bad_str.stderr
+++ b/tests/ui/bad_str.stderr
@@ -4,8 +4,8 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
 6 | #[make_dst_factory]
   | ^^^^^^^^^^^^^^^^^^^
   |
-  = note: source type: `(*const MaybeUninit<(i32, u8)>, usize)` (128 bits)
-  = note: target type: `*const BadStr` (64 bits)
+  = note: source type: `*mut BadStr` (64 bits)
+  = note: target type: `(*mut u8, usize)` (128 bits)
   = note: this error originates in the attribute macro `make_dst_factory` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
@@ -16,4 +16,14 @@ error[E0512]: cannot transmute between types of different sizes, or dependently-
   |
   = note: source type: `(*mut u8, usize)` (128 bits)
   = note: target type: `*mut BadStr` (64 bits)
+  = note: this error originates in the attribute macro `make_dst_factory` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
+ --> tests/ui/bad_str.rs:6:1
+  |
+6 | #[make_dst_factory]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: source type: `(*const MaybeUninit<(i32, u8)>, usize)` (128 bits)
+  = note: target type: `*const BadStr` (64 bits)
   = note: this error originates in the attribute macro `make_dst_factory` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/no_comma_after_debug.rs
+++ b/tests/ui/no_comma_after_debug.rs
@@ -1,0 +1,10 @@
+use dst_factory::make_dst_factory;
+
+#[make_dst_factory(create, debug no_std)]
+struct NoCommaAfterDebug {
+    id: i32,
+    data: str,
+}
+
+fn main() {
+}

--- a/tests/ui/no_comma_after_debug.stderr
+++ b/tests/ui/no_comma_after_debug.stderr
@@ -1,0 +1,5 @@
+error: Expected comma after debug
+ --> tests/ui/no_comma_after_debug.rs:3:34
+  |
+3 | #[make_dst_factory(create, debug no_std)]
+  |                                  ^^^^^^

--- a/tests/ui/no_comma_after_eq.rs
+++ b/tests/ui/no_comma_after_eq.rs
@@ -1,0 +1,10 @@
+use dst_factory::make_dst_factory;
+
+#[make_dst_factory(create, debug, eq no_std)]
+struct NoCommaAfterEq {
+    id: i32,
+    data: str,
+}
+
+fn main() {
+}

--- a/tests/ui/no_comma_after_eq.stderr
+++ b/tests/ui/no_comma_after_eq.stderr
@@ -1,0 +1,5 @@
+error: Expected comma after eq
+ --> tests/ui/no_comma_after_eq.rs:3:38
+  |
+3 | #[make_dst_factory(create, debug, eq no_std)]
+  |                                      ^^^^^^

--- a/tests/ui/no_comma_after_hash.rs
+++ b/tests/ui/no_comma_after_hash.rs
@@ -1,0 +1,10 @@
+use dst_factory::make_dst_factory;
+
+#[make_dst_factory(create, debug, eq, hash no_std)]
+struct NoCommaAfterHash {
+    id: i32,
+    data: str,
+}
+
+fn main() {
+}

--- a/tests/ui/no_comma_after_hash.stderr
+++ b/tests/ui/no_comma_after_hash.stderr
@@ -1,0 +1,5 @@
+error: Expected comma after hash
+ --> tests/ui/no_comma_after_hash.rs:3:44
+  |
+3 | #[make_dst_factory(create, debug, eq, hash no_std)]
+  |                                            ^^^^^^

--- a/tests/ui/no_comma_after_ord.rs
+++ b/tests/ui/no_comma_after_ord.rs
@@ -1,0 +1,10 @@
+use dst_factory::make_dst_factory;
+
+#[make_dst_factory(create, eq, ord no_std)]
+struct NoCommaAfterOrd {
+    id: i32,
+    data: str,
+}
+
+fn main() {
+}

--- a/tests/ui/no_comma_after_ord.stderr
+++ b/tests/ui/no_comma_after_ord.stderr
@@ -1,0 +1,5 @@
+error: Expected comma after ord
+ --> tests/ui/no_comma_after_ord.rs:3:36
+  |
+3 | #[make_dst_factory(create, eq, ord no_std)]
+  |                                    ^^^^^^

--- a/tests/ui/no_std_serde.rs
+++ b/tests/ui/no_std_serde.rs
@@ -1,0 +1,37 @@
+
+#![allow(dead_code)]
+
+extern crate alloc;
+
+use dst_factory::make_dst_factory;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[make_dst_factory(no_std, deserialize)]
+struct NoStdSerdeStr {
+    id: i32,
+    data: str,
+}
+
+#[derive(Serialize)]
+#[make_dst_factory(no_std, deserialize)]
+struct NoStdSerdeSlice {
+    id: i32,
+    data: [u32],
+}
+
+fn main() {
+    // Verify str round-trip compiles
+    let msg = NoStdSerdeStr::build(1, "hello");
+    let json = serde_json::to_string(&*msg).unwrap();
+    let restored: alloc::boxed::Box<NoStdSerdeStr> = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.id, 1);
+    assert_eq!(&restored.data, "hello");
+
+    // Verify slice round-trip compiles
+    let reading = NoStdSerdeSlice::build_from_slice(2, &[10, 20, 30]);
+    let json = serde_json::to_string(&*reading).unwrap();
+    let restored: alloc::boxed::Box<NoStdSerdeSlice> = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.id, 2);
+    assert_eq!(&restored.data, &[10, 20, 30]);
+}


### PR DESCRIPTION
New macro flags for trait implementations:
- debug: generates Debug for the DST struct itself
- eq: generates PartialEq + Eq for the DST struct
- hash: generates Hash for the DST struct
- ord: generates PartialOrd + Ord for the DST struct -

New conversion methods (always generated):
- into_arc(Box<Self>) -> Arc<Self>
- into_rc(Box<Self>) -> Rc<Self> These perform a single-allocation conversion by extracting fat pointer metadata from the source, allocating the target with refcount header, memcpy-ing the DST data, and deallocating the source Box.

Serde improvements:
- Fix no_std: use conditional alloc::/std:: paths for Box, Vec, and String in all generated serde code (was hardcoded to std::)
- Use Cow<str> with #[serde(borrow)] for str tail deserialization across all pointer types (Box, Arc, Rc), avoiding an intermediate String heap allocation when the deserializer supports borrowing